### PR TITLE
Adopt virtual threads and transactional optimizations for higher throughput

### DIFF
--- a/src/main/java/com/study/events/domain/service/EventService.java
+++ b/src/main/java/com/study/events/domain/service/EventService.java
@@ -16,6 +16,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @AllArgsConstructor
@@ -25,7 +26,11 @@ public class EventService implements EventInputPort {
   private final UserPersistenceMapper userPersistenceMapper;
 
   @Override
+  @Transactional
   public Event createEvent(Event event) {
+    // Wrapping the workflow in a single transaction keeps all database calls on the same
+    // connection, eliminating extra round trips and ensuring we do not hold locks longer than
+    // necessary when many requests try to create events concurrently.
     log.info("Create event: {}", event);
 
     var userOptional = userPersistencePort.findById(event.getOwnerId().toString());
@@ -42,7 +47,10 @@ public class EventService implements EventInputPort {
   }
 
   @Override
+  @Transactional
   public Event updateEvent(Event event, String eventId) {
+    // Using a transactional boundary here prevents multiple threads from interleaving updates to
+    // the same event record, reducing contention and avoiding redundant reloads of the entity.
     log.info("Update event with Id: {}", eventId);
 
     var eventOptional = eventPersistencePort.findById(eventId);
@@ -64,7 +72,10 @@ public class EventService implements EventInputPort {
   }
 
   @Override
+  @Transactional(readOnly = true)
   public Event findById(String eventId) {
+    // A read-only transaction allows Hibernate to skip dirty checking, which keeps lookups cheap
+    // even while hundreds of concurrent readers are active.
     log.info("Searching event: {}", eventId);
 
     return eventPersistencePort.findById(eventId)
@@ -72,12 +83,18 @@ public class EventService implements EventInputPort {
   }
 
   @Override
+  @Transactional
   public void deleteEvent(String eventId) {
+    // Running deletes inside a transaction gives the persistence provider a chance to reuse the
+    // same connection that fetched the entity, reducing lock time and improving throughput.
     eventPersistencePort.delete(eventId);
   }
 
   @Override
+  @Transactional
   public int addUserToEvent(String eventId, EventAddUserRequest eventAddUserRequest) {
+    // The attendees counter is sensitive to lost updates; executing the workflow within a single
+    // transaction lets optimistic locking detect conflicts when many users join or leave at once.
     log.info("Adding user " + eventAddUserRequest + " to event" + eventId);
 
     var event = findById(eventId);

--- a/src/main/java/com/study/events/domain/service/UserService.java
+++ b/src/main/java/com/study/events/domain/service/UserService.java
@@ -7,6 +7,7 @@ import com.study.events.domain.exception.UserException;
 import com.study.events.domain.model.User;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @AllArgsConstructor
@@ -14,13 +15,20 @@ public class UserService implements UserInputPort {
   private final UserPersistencePort userPersistencePort;
 
   @Override
+  @Transactional
   public User createUser(User user) {
+    // Persisting the user within a dedicated transaction makes the write inexpensive to retry and
+    // avoids holding on to pooled connections when the system is under heavy sign-up load.
     log.info("Create user: {}", user);
     return userPersistencePort.save(user);
   }
 
   @Override
+  @Transactional(readOnly = true)
   public User findUserById(String id) {
+    // Marking the lookup as read-only lets Hibernate serve the request without tracking changes,
+    // which keeps the session lightweight and increases the number of concurrent lookups we can
+    // handle before exhausting memory or CPU.
     log.info("Searching user: {}", id);
 
     return userPersistencePort.findById(id)
@@ -28,14 +36,21 @@ public class UserService implements UserInputPort {
   }
 
   @Override
+  @Transactional
   public User updateUser(User user, String id) {
+    // Serialising the update through a transaction ensures the record is refreshed atomically,
+    // keeping concurrent updates from stepping on one another.
     log.info("Updating user: {}", id);
 
     return userPersistencePort.update(user, id);
   }
 
   @Override
+  @Transactional
   public void deleteUser(User user) {
+    // Enclosing deletions in a transaction encourages Hibernate to reuse the same JDBC connection
+    // for cascade operations, which lowers lock contention when many accounts are removed
+    // simultaneously.
     log.info("Deleting user: {}", user);
     userPersistencePort.deleteUser(user);
   }

--- a/src/main/java/com/study/events/infrastructure/adapters/configs/VirtualThreadConfiguration.java
+++ b/src/main/java/com/study/events/infrastructure/adapters/configs/VirtualThreadConfiguration.java
@@ -1,0 +1,33 @@
+package com.study.events.infrastructure.adapters.configs;
+
+import java.time.Duration;
+import org.springframework.boot.web.embedded.tomcat.TomcatProtocolHandlerCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.VirtualThreadTaskExecutor;
+
+@Configuration
+public class VirtualThreadConfiguration {
+
+  @Bean
+  public VirtualThreadTaskExecutor applicationTaskExecutor() {
+    var executor = new VirtualThreadTaskExecutor("events-vt-");
+    executor.setVirtualThreadFactory(Thread.ofVirtual().name("events-vt-", 0).factory());
+    executor.setShutdownTimeout(Duration.ofSeconds(2));
+    // Virtual threads allow the servlet container and any @Async tasks to scale to thousands of
+    // concurrent requests without blocking platform threads, dramatically improving throughput
+    // under load while keeping the programming model synchronous.
+    return executor;
+  }
+
+  @Bean
+  public TomcatProtocolHandlerCustomizer<?> protocolHandlerVirtualThreadExecutor(
+      VirtualThreadTaskExecutor applicationTaskExecutor) {
+    return protocolHandler -> {
+      // Reuse the same virtual-thread executor for Tomcat so that every connection is handled by a
+      // lightweight fiber instead of a heavyweight platform thread, removing a major concurrency
+      // bottleneck in the classic request-per-thread model.
+      protocolHandler.setExecutor(applicationTaskExecutor);
+    };
+  }
+}

--- a/src/main/java/com/study/events/infrastructure/adapters/outbound/persistence/EventPersistenceAdapter.java
+++ b/src/main/java/com/study/events/infrastructure/adapters/outbound/persistence/EventPersistenceAdapter.java
@@ -49,6 +49,7 @@ public class EventPersistenceAdapter implements EventPersistencePort {
 
       event.setId(eventSaved.getId());
       var eventEntity = eventPersistenceMapper.toEventEntity(event);
+      eventEntity.setVersion(eventSaved.getVersion());
       // Deferring the flush allows multiple updates triggered by concurrent requests to be grouped
       // together, reducing database round trips and increasing throughput.
       eventEntity = eventRepository.save(eventEntity);

--- a/src/main/java/com/study/events/infrastructure/adapters/outbound/persistence/EventPersistenceAdapter.java
+++ b/src/main/java/com/study/events/infrastructure/adapters/outbound/persistence/EventPersistenceAdapter.java
@@ -21,7 +21,9 @@ public class EventPersistenceAdapter implements EventPersistencePort {
   public Event save(Event event) {
     var eventEntity = eventPersistenceMapper.toEventEntity(event);
     eventEntity.setOwner(event.getOwner());
-    eventEntity = eventRepository.saveAndFlush(eventEntity);
+    // save(...) avoids the immediate flush and lets Hibernate batch work, which keeps JDBC
+    // connections free for other virtual threads while transactions are still open.
+    eventEntity = eventRepository.save(eventEntity);
     return eventPersistenceMapper.toEvent(eventEntity);
   }
 
@@ -47,7 +49,9 @@ public class EventPersistenceAdapter implements EventPersistencePort {
 
       event.setId(eventSaved.getId());
       var eventEntity = eventPersistenceMapper.toEventEntity(event);
-      eventEntity = eventRepository.saveAndFlush(eventEntity);
+      // Deferring the flush allows multiple updates triggered by concurrent requests to be grouped
+      // together, reducing database round trips and increasing throughput.
+      eventEntity = eventRepository.save(eventEntity);
 
       return eventPersistenceMapper.toEvent(eventEntity);
     } else {
@@ -57,13 +61,12 @@ public class EventPersistenceAdapter implements EventPersistencePort {
 
   @Override
   public void delete(String eventId) {
-    var eventSavedOptional = findById(eventId);
-    if (eventSavedOptional.isEmpty()) {
+    var uuid = UUID.fromString(eventId);
+    if (!eventRepository.existsById(uuid)) {
       throw new EventException(EventErrors.EVENT_NOT_FOUND);
     }
-    var eventSaved = eventSavedOptional.get();
-    var eventEntity = eventPersistenceMapper.toEventEntity(eventSaved);
-    eventRepository.delete(eventEntity);
-    eventRepository.flush();
+    // Deleting directly by identifier short-circuits entity materialisation, shrinking the amount
+    // of work each concurrent request performs and keeping the persistence context lean.
+    eventRepository.deleteById(uuid);
   }
 }

--- a/src/main/java/com/study/events/infrastructure/adapters/outbound/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/study/events/infrastructure/adapters/outbound/persistence/UserPersistenceAdapter.java
@@ -21,7 +21,9 @@ public class UserPersistenceAdapter implements UserPersistencePort {
 
   @Override
   public User save(User user) {
-    var userEntity = userRepository.saveAndFlush(userPersistenceMapper.toUserEntity(user));
+    // save(...) postpones the flush so that multiple virtual threads can enqueue their inserts
+    // without immediately blocking on the database connection.
+    var userEntity = userRepository.save(userPersistenceMapper.toUserEntity(user));
     return userPersistenceMapper.toUser(userEntity);
   }
 
@@ -38,7 +40,9 @@ public class UserPersistenceAdapter implements UserPersistencePort {
     if (userSavedOptional.isPresent()) {
       var userSaved = userSavedOptional.get();
       user.setId(userSaved.getId());
-      var userEntity = userRepository.saveAndFlush(userPersistenceMapper.toUserEntity(user));
+      // Deferring flush operations gives Hibernate room to coalesce updates, which is especially
+      // helpful when many concurrent profile edits happen at the same time.
+      var userEntity = userRepository.save(userPersistenceMapper.toUserEntity(user));
       return userPersistenceMapper.toUser(userEntity);
     } else {
       throw new UserException(UserErrors.USER_NOT_FOUND);
@@ -47,8 +51,9 @@ public class UserPersistenceAdapter implements UserPersistencePort {
 
   @Override
   public void deleteUser(User user) {
-    userRepository.delete(userPersistenceMapper.toUserEntity(user));
-    userRepository.flush();
+    // Deleting by identifier skips entity reconstruction and shortens the critical section when
+    // multiple virtual threads attempt to purge users concurrently.
+    userRepository.deleteById(user.getId());
   }
 
   @Override

--- a/src/main/java/com/study/events/infrastructure/adapters/outbound/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/study/events/infrastructure/adapters/outbound/persistence/UserPersistenceAdapter.java
@@ -42,7 +42,9 @@ public class UserPersistenceAdapter implements UserPersistencePort {
       user.setId(userSaved.getId());
       // Deferring flush operations gives Hibernate room to coalesce updates, which is especially
       // helpful when many concurrent profile edits happen at the same time.
-      var userEntity = userRepository.save(userPersistenceMapper.toUserEntity(user));
+      var userEntityToUpdate = userPersistenceMapper.toUserEntity(user);
+      userEntityToUpdate.setVersion(userSaved.getVersion());
+      var userEntity = userRepository.save(userEntityToUpdate);
       return userPersistenceMapper.toUser(userEntity);
     } else {
       throw new UserException(UserErrors.USER_NOT_FOUND);

--- a/src/main/java/com/study/events/infrastructure/adapters/outbound/persistence/entity/AuditingEntity.java
+++ b/src/main/java/com/study/events/infrastructure/adapters/outbound/persistence/entity/AuditingEntity.java
@@ -3,6 +3,7 @@ package com.study.events.infrastructure.adapters.outbound.persistence.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 import lombok.Data;
 import org.springframework.data.annotation.CreatedBy;
@@ -31,4 +32,10 @@ public abstract class AuditingEntity {
   @LastModifiedDate
   @Column(name = "last_modified_date", nullable = false)
   private LocalDateTime lastModifiedDate;
+
+  @Version
+  @Column(name = "version", nullable = false)
+  private long version;
+  // The lightweight optimistic lock guards against lost updates when thousands of virtual threads
+  // try to change the same row, while still allowing readers to proceed without blocking.
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 spring:
   application:
     name: events
+  threads:
+    virtual:
+      enabled: true # Enable Loom virtual threads globally so request handling scales beyond the limits of platform threads.
   doc:
     swagger-ui:
       url: /openapi.yml
@@ -43,15 +46,6 @@ spring:
         order_updates: true
         default_batch_fetch_size: 50
         generate_statistics: false
-
-  task:
-    execution:
-      thread-name-prefix: async-exec-
-      pool:
-        core-size: 16
-        max-size: 32
-        queue-capacity: 5000
-        keep-alive: 60s
 
 server:
   port: 8080


### PR DESCRIPTION
## Summary
- enable Project Loom virtual threads for Tomcat and application tasks to boost request concurrency
- wrap domain services in transactions and add optimistic locking to avoid lost updates under load
- streamline persistence adapters to defer flushes and reduce database contention for concurrent operations

## Testing
- ./mvnw -q test *(fails: Network is unreachable while downloading Maven Wrapper distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68d93b0a0b1c8329894aa5ac8389798f